### PR TITLE
Correct startTime usage in unit tests

### DIFF
--- a/test/InsurCircle.test.js
+++ b/test/InsurCircle.test.js
@@ -19,7 +19,7 @@ contract('InsurCircle', (accounts) => {
       '0x0000000000000000000000000000000000000000',
       ORGANIZER,
       ROUND_PERIOD_IN_SEC,
-      START_TIME.getTime(),
+      Math.floor(START_TIME.getTime() / 1000),
       CONTRIBUTION_SIZE,
       [MEMBER_0, MEMBER_1, MEMBER_2]
     )
@@ -31,7 +31,7 @@ contract('InsurCircle', (accounts) => {
         '0x0000000000000000000000000000000000000000',
         ORGANIZER,
         ROUND_PERIOD_IN_SEC,
-        START_TIME.getTime(),
+        Math.floor(START_TIME.getTime() / 1000),
         CONTRIBUTION_SIZE,
         [MEMBER_0, MEMBER_1, MEMBER_2]
       )

--- a/test/TestableInsurCircle.test.js
+++ b/test/TestableInsurCircle.test.js
@@ -19,7 +19,7 @@ contract('TestableInsurCircle', (accounts) => {
       '0x0000000000000000000000000000000000000000',
       ORGANIZER,
       ROUND_PERIOD_IN_SEC,
-      START_TIME.getTime(),
+      Math.floor(START_TIME.getTime()),
       CONTRIBUTION_SIZE,
       [MEMBER_0, MEMBER_1, MEMBER_2]
     )


### PR DESCRIPTION
+ Instead of `ms`, should be `s`